### PR TITLE
other-extensions: Added utils for .toString() and working tests

### DIFF
--- a/src/main/kotlin/ai/blindspot/ktoolz/extensions/IterableExtensions.kt
+++ b/src/main/kotlin/ai/blindspot/ktoolz/extensions/IterableExtensions.kt
@@ -465,3 +465,34 @@ fun <A, B, C> List<Triple<A, B, C>>.flattenToLists(): Triple<List<A>, List<B>, L
 fun <T> Iterable<T>.toNavigableSet(comparator: Comparator<in T>): NavigableSet<T> {
     return toCollection(TreeSet(comparator))
 }
+
+/**
+ * Formats a collection of [TItem]s to a readable string like "3 colors: red, yellow, green".
+ *
+ * Each item is converted by [itemToString] to a string representation whose length is restricted by [itemLength]
+ *  and the output length by [totalLength]. A [separator] (default = ", ") is placed between the string representation.
+ *
+ * @param itemsType a string describing the collection items, such as "colors", "employees" etc.; default = "items"
+ * @param itemToString a lambda converting each item to its string representation.
+ */
+inline fun <TItem> Iterable<TItem>.itemsToString(
+    itemsType: String = "items",
+    separator: String = ", ",
+    itemLength: Int = 30,
+    totalLength: Int = 200,
+    itemToString: (TItem) -> String = { item -> item.toShortString() }
+): String {
+    val sb = StringBuilder("${this.count()} $itemsType")
+    var currentSeparator = ": "  // before the first item
+    for (item in this) {
+        sb.append(currentSeparator)
+        currentSeparator = separator // before other than first item
+        val short: String = if (item == null) "null" else itemToString(item).restrictLengthWithEllipsis(itemLength)
+        if (short.length + sb.length > totalLength) {
+            sb.append("…")
+            break // no more items will fit into [totalLength]
+        }
+        sb.append(short)
+    }
+    return sb.toString().restrictLengthWithEllipsis(totalLength)
+}

--- a/src/main/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensions.kt
+++ b/src/main/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensions.kt
@@ -87,3 +87,70 @@ inline fun <T : Any> T.applyIf(shouldApply: Boolean, block: T.() -> Unit): T {
     return this
 }
 
+/**
+ * Shortens the string if needed. For example, returns "ABCD…" when called "ABCDEFHG.(5, "…")
+ */
+fun String.restrictLengthWithEllipsis(maxLength: Int, ellipsis: String = "…"): String {
+    if (this.length <= maxLength) return this
+    return this.substring(0, maxLength - ellipsis.length) + ellipsis
+}
+
+/**
+ * Creates a string like "className(details)", for example "Double(42.0)"
+ * Useful for implementing .toString() method (but in such case the first parameter MUST be passed).
+ */
+fun Any.toLongDebugString(description: String? = null, brackets: String = "()", className: String? = null): String {
+    val actualDescription = description ?: this.toString()
+    val actualClassName = className ?: this.javaClass.simpleName
+    val actualBrackets = if (brackets.length == 2) brackets else "<>"
+    return "$actualClassName${actualBrackets[0]}$actualDescription${actualBrackets[1]}"
+}
+
+/**
+ * Extracts the essential information from an object (most usually a string), whose toString() call result
+ * has a similar format as the output of function [toLongDebugString] .
+ * If the format is not similar, it simply returns this.toString() .
+ *
+ * For example, returns "42.0" for string "Double(42.0)".
+ * Returns "John 42, Peter 31" for string "EmployeeList{John 42, Peter 31}"
+ *
+ * Typical usage: the toString() method of a large collection-like object should contain only a very short description
+ *  of each collection item. This is done, for example, in [itemsToDebugString] ().
+ */
+fun Any?.toShortDebugString(): String {
+    val longString = this.toString()
+    if (longString.isEmpty()) return "EMPTY STRING" // Should not happen
+    val startsWithLetter = longString[0].let { it in 'a'..'z' || it in 'A'..'Z' }
+    if (!startsWithLetter) return longString // The format does not resemble an output of [toLongDebugString]
+
+    val bracketPairs = setOf("()", "[]", "<>", "{}")
+    for (pair in bracketPairs) {
+        if (longString.last() == pair[1]) {
+            val after = longString.substringAfter(pair[0])
+            if (after.length < 2) return longString
+            return after.substring(0, after.length - 1) // Omit the last char
+        }
+    }
+    return longString // The format does not resemble an output of [toLongDebugString]
+}
+
+/**
+ * Formats a collection to a readable string like "3 colors: red, yellow, green".
+ */
+inline fun <T> Collection<T>.itemsToDebugString(
+    itemsType: String = "items", // or "employees" etc.
+    separator: String = ", ", // inserted between (string representations of) collection items
+    itemLength: Int = 30, // max length
+    totalLength: Int = 200,
+    itemToString: (T) -> String = { item -> item.toShortDebugString() }
+): String {
+    val sb = StringBuilder("${this.size} $itemsType")
+    var currentSeparator = ": "  // we want to return something like: "3 items: item1, item2, item3"
+    for (item in this) {
+        val short: String = if (item == null) "NULL" else itemToString(item).restrictLengthWithEllipsis(itemLength)
+        if (short.length + sb.length >= totalLength) return sb.apply { append("…") }.toString()
+        sb.append(currentSeparator + short)
+        currentSeparator = separator
+    }
+    return sb.toString()
+}

--- a/src/main/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensions.kt
+++ b/src/main/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensions.kt
@@ -88,42 +88,38 @@ inline fun <T : Any> T.applyIf(shouldApply: Boolean, block: T.() -> Unit): T {
 }
 
 /**
- * Shortens the string if needed. For example, returns "ABCD…" when called "ABCDEFHG.(5, "…")
+ * Creates a string like "className(description)", for example "Double(42.0)"
+ * Useful either for implementing .toString() override.
+ *
+ * @param description the content to be displayed inside the brackets.
+ * @param brackets a two-character string like "{}", default = "()".
+ * @param className the string to be displayed before the brackets; default = the class name of [this].
  */
-fun String.restrictLengthWithEllipsis(maxLength: Int, ellipsis: String = "…"): String {
-    if (this.length <= maxLength) return this
-    return this.substring(0, maxLength - ellipsis.length) + ellipsis
-}
-
-/**
- * Creates a string like "className(details)", for example "Double(42.0)"
- * Useful for implementing .toString() method (but in such case the first parameter MUST be passed).
- */
-fun Any.toLongDebugString(description: String? = null, brackets: String = "()", className: String? = null): String {
-    val actualDescription = description ?: this.toString()
+fun Any.toLongString(description: String, brackets: String = "()", className: String? = null): String {
     val actualClassName = className ?: this.javaClass.simpleName
     val actualBrackets = if (brackets.length == 2) brackets else "<>"
-    return "$actualClassName${actualBrackets[0]}$actualDescription${actualBrackets[1]}"
+    return "$actualClassName${actualBrackets[0]}$description${actualBrackets[1]}"
 }
+
+private val bracketPairs = setOf("()", "[]", "<>", "{}")
 
 /**
  * Extracts the essential information from an object (most usually a string), whose toString() call result
- * has a similar format as the output of function [toLongDebugString] .
+ * has a similar format as the output of function [toLongString] .
  * If the format is not similar, it simply returns this.toString() .
  *
- * For example, returns "42.0" for string "Double(42.0)".
- * Returns "John 42, Peter 31" for string "EmployeeList{John 42, Peter 31}"
+ * For example, returns "42.0" if [this] is a string "Double(42.0)".
+ * Returns "John 42, Peter 31" for string "EmployeeList{John 42, Peter 31}".
  *
  * Typical usage: the toString() method of a large collection-like object should contain only a very short description
- *  of each collection item. This is done, for example, in [itemsToDebugString] ().
+ *  of each collection item. This is done, for example, in [itemsToString] ().
  */
-fun Any?.toShortDebugString(): String {
+fun Any?.toShortString(): String {
     val longString = this.toString()
     if (longString.isEmpty()) return "EMPTY STRING" // Should not happen
-    val startsWithLetter = longString[0].let { it in 'a'..'z' || it in 'A'..'Z' }
-    if (!startsWithLetter) return longString // The format does not resemble an output of [toLongDebugString]
 
-    val bracketPairs = setOf("()", "[]", "<>", "{}")
+    if (!longString.startsWithLetter()) return longString // The format does not resemble an output of [toLongString]
+
     for (pair in bracketPairs) {
         if (longString.last() == pair[1]) {
             val after = longString.substringAfter(pair[0])
@@ -131,26 +127,5 @@ fun Any?.toShortDebugString(): String {
             return after.substring(0, after.length - 1) // Omit the last char
         }
     }
-    return longString // The format does not resemble an output of [toLongDebugString]
-}
-
-/**
- * Formats a collection to a readable string like "3 colors: red, yellow, green".
- */
-inline fun <T> Collection<T>.itemsToDebugString(
-    itemsType: String = "items", // or "employees" etc.
-    separator: String = ", ", // inserted between (string representations of) collection items
-    itemLength: Int = 30, // max length
-    totalLength: Int = 200,
-    itemToString: (T) -> String = { item -> item.toShortDebugString() }
-): String {
-    val sb = StringBuilder("${this.size} $itemsType")
-    var currentSeparator = ": "  // we want to return something like: "3 items: item1, item2, item3"
-    for (item in this) {
-        val short: String = if (item == null) "NULL" else itemToString(item).restrictLengthWithEllipsis(itemLength)
-        if (short.length + sb.length >= totalLength) return sb.apply { append("…") }.toString()
-        sb.append(currentSeparator + short)
-        currentSeparator = separator
-    }
-    return sb.toString()
+    return longString // The format does not resemble an output of [toLongString]
 }

--- a/src/main/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensions.kt
+++ b/src/main/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensions.kt
@@ -89,7 +89,7 @@ inline fun <T : Any> T.applyIf(shouldApply: Boolean, block: T.() -> Unit): T {
 
 /**
  * Creates a string like "className(description)", for example "Double(42.0)"
- * Useful either for implementing .toString() override.
+ * Useful e.g. for implementing .toString() override.
  *
  * @param description the content to be displayed inside the brackets.
  * @param brackets a two-character string like "{}", default = "()".
@@ -123,8 +123,7 @@ fun Any?.toShortString(): String {
     for (pair in bracketPairs) {
         if (longString.last() == pair[1]) {
             val after = longString.substringAfter(pair[0])
-            if (after.length < 2) return longString
-            return after.substring(0, after.length - 1) // Omit the last char
+            return if (after.length < 2) longString else after.substring(0, after.length - 1) // Omit the last char
         }
     }
     return longString // The format does not resemble an output of [toLongString]

--- a/src/main/kotlin/ai/blindspot/ktoolz/extensions/StringExtensions.kt
+++ b/src/main/kotlin/ai/blindspot/ktoolz/extensions/StringExtensions.kt
@@ -1,0 +1,16 @@
+package ai.blindspot.ktoolz.extensions
+
+/**
+ * Shortens the string to [maxLength]; in such case, appends the [ellipsis] (typically "…" ).
+ *
+ * For example, returns "ABCD…" when called for "ABCDEFHG".(5, "…")
+ */
+fun String.restrictLengthWithEllipsis(maxLength: Int, ellipsis: String = "…"): String
+        =  if (this.length <= maxLength) this else this.substring(0, maxLength - ellipsis.length) + ellipsis
+
+/**
+ * Returns true if the string starts with a latin letter a-z or A-Z
+ */
+fun String.startsWithLetter()
+        = this.contains(regexStartsWithLetter)
+private val regexStartsWithLetter = "^[a-zA-Z]".toRegex()

--- a/src/test/kotlin/ai/blindspot/ktoolz/extensions/IterableExtensionsTest.kt
+++ b/src/test/kotlin/ai/blindspot/ktoolz/extensions/IterableExtensionsTest.kt
@@ -219,4 +219,10 @@ class IterableExtensionsTest {
 
         assertEquals(expected, input.flattenToLists())
     }
+    @Test
+    fun itemsToString() {
+        val itemToString: (Int) -> String = {i -> "NUM$i"}
+        val result = listOf(10, 20).itemsToString("numbers", itemToString = itemToString )
+        assertEquals("2 numbers: NUM10, NUM20", result)
+    }
 }

--- a/src/test/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensionsTest.kt
+++ b/src/test/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensionsTest.kt
@@ -153,28 +153,17 @@ internal class OtherExtensionsTest {
     }
 
     @Test
-    fun restrictLengthWithEllipsis() {
-        val result = "ABCDEFGHIJK".restrictLengthWithEllipsis(8, "elip")
-        assertEquals("ABCDelip", result)
+    fun toLongString() {
+        // With default parameters
+        assertEquals("Double(42.0)", 42.0.toLongString("42.0"))
+        // With explicit parameters
+        assertEquals("MyClass[short]", "Any object".toLongString("short","[]", className = "MyClass"))
     }
 
     @Test
-    fun toLongDebugString() {
-        assertEquals("Double(42.0)", 42.0.toLongDebugString())
-        assertEquals("MyClass[short]", "Any object".toLongDebugString("short","[]", className = "MyClass"))
-    }
-
-    @Test
-    fun toShortDebugString() {
+    fun toShortString() {
         val short = "SHORT"
-        val long = short.toLongDebugString()
-        assertEquals( short, long.toShortDebugString())
-    }
-
-    @Test
-    fun itemsToDebugString() {
-        val itemToString : (Int)->String = {i -> "NUM$i"}
-        val result = setOf(10, 20).itemsToDebugString("numbers", itemToString = itemToString )
-        assertEquals("2 numbers: NUM10, NUM20", result)
+        val long = short.toLongString(short)
+        assertEquals(short, long.toShortString())
     }
 }

--- a/src/test/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensionsTest.kt
+++ b/src/test/kotlin/ai/blindspot/ktoolz/extensions/OtherExtensionsTest.kt
@@ -151,4 +151,30 @@ internal class OtherExtensionsTest {
         }, block = { set(0, 0) }))
         assertEquals(1, listUnderTest[0])
     }
+
+    @Test
+    fun restrictLengthWithEllipsis() {
+        val result = "ABCDEFGHIJK".restrictLengthWithEllipsis(8, "elip")
+        assertEquals("ABCDelip", result)
+    }
+
+    @Test
+    fun toLongDebugString() {
+        assertEquals("Double(42.0)", 42.0.toLongDebugString())
+        assertEquals("MyClass[short]", "Any object".toLongDebugString("short","[]", className = "MyClass"))
+    }
+
+    @Test
+    fun toShortDebugString() {
+        val short = "SHORT"
+        val long = short.toLongDebugString()
+        assertEquals( short, long.toShortDebugString())
+    }
+
+    @Test
+    fun itemsToDebugString() {
+        val itemToString : (Int)->String = {i -> "NUM$i"}
+        val result = setOf(10, 20).itemsToDebugString("numbers", itemToString = itemToString )
+        assertEquals("2 numbers: NUM10, NUM20", result)
+    }
 }

--- a/src/test/kotlin/ai/blindspot/ktoolz/extensions/StringExtensionsTest.kt
+++ b/src/test/kotlin/ai/blindspot/ktoolz/extensions/StringExtensionsTest.kt
@@ -1,0 +1,22 @@
+package ai.blindspot.ktoolz.extensions
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+internal class StringExtensionsTest {
+
+    @Test
+    fun restrictLengthWithEllipsis() {
+        val result = "ABCDEFGHIJK".restrictLengthWithEllipsis(8, "elip")
+        assertEquals("ABCDelip", result)
+    }
+
+    @Test
+    fun startsWithLetter(){
+        val examples = mapOf("a lPha" to true, "Běta7" to true, "Čermák" to false, " delta" to false, "30" to false, "_" to false)
+        for ( (key, value) in examples) {
+            val result = key.startsWithLetter()
+            assertEquals(value, result, "The call \"$key\".startsWithLetter() should return $value")
+        }
+    }
+}


### PR DESCRIPTION
I added four functions (with receivers) at the end of OtherExtensions.kt - they enable creating of informative, non too verbose .toString() overrides for complex objects.

I could not run "all tests in project", but OtherExtensionsTest has all tests green.

Commits:
* other-extensions: Added utils for .toString() and working tests